### PR TITLE
Separate l1 and l2 namespaces

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -8,9 +8,14 @@ namespace LCache;
  */
 final class Address implements \Serializable
 {
-    /** @var string|null */
+    /**
+     * @var string|null
+     */
     protected $bin;
-    /** @var string|null */
+
+    /**
+     * @var string|null
+     */
     protected $key;
 
     /**
@@ -28,6 +33,7 @@ final class Address implements \Serializable
 
     /**
      * Get the bin.
+     *
      * @return string|null
      */
     public function getBin()
@@ -37,6 +43,7 @@ final class Address implements \Serializable
 
     /**
      * Get the key.
+     *
      * @return string|null
      */
     public function getKey()
@@ -46,6 +53,7 @@ final class Address implements \Serializable
 
     /**
      * Return true if address refers to everything in the entire bin.
+     *
      * @return boolean
      */
     public function isEntireBin()
@@ -55,6 +63,7 @@ final class Address implements \Serializable
 
     /**
      * Return true if address refers to everything in the entire cache.
+     *
      * @return boolean
      */
     public function isEntireCache()
@@ -65,7 +74,8 @@ final class Address implements \Serializable
     /**
      * Return true if this object refers to any of the same objects as the
      * provided Address object.
-     * @param Address $address
+     *
+     * @param  Address $address
      * @return boolean
      */
     public function isMatch(Address $address)
@@ -106,6 +116,7 @@ final class Address implements \Serializable
 
     /**
      * Unpack a serialized Address into this object.
+     *
      * @param string $serialized
      */
     public function unserialize($serialized)

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -25,6 +25,7 @@ final class Entry
 
     /**
      * Return the Address for this entry.
+     *
      * @return Address
      */
     public function getAddress()
@@ -34,6 +35,7 @@ final class Entry
 
     /**
      * Return the time-to-live for this entry.
+     *
      * @return integer
      */
     public function getTTL()
@@ -41,8 +43,8 @@ final class Entry
         if (is_null($this->expiration)) {
             return null;
         }
-        if ($this->expiration > $_SERVER['REQUEST_TIME']) {
-            return $this->expiration - $_SERVER['REQUEST_TIME'];
+        if ($this->expiration > $this->created) {
+            return $this->expiration - $this->created;
         }
         return 0;
     }

--- a/src/LX.php
+++ b/src/LX.php
@@ -7,13 +7,16 @@ namespace LCache;
  */
 abstract class LX
 {
+    protected $created_time;
+
     abstract public function getEntry(Address $address);
     abstract public function getHits();
     abstract public function getMisses();
 
     /**
      * Fetch a value from the cache.
-     * @param Address $address
+     *
+     * @param  Address $address
      * @return string|null
      */
     public function get(Address $address)
@@ -27,7 +30,8 @@ abstract class LX
 
     /**
      * Determine whether or not the specified Address exists in the cache.
-     * @param Address $address
+     *
+     * @param  Address $address
      * @return boolean
      */
     public function exists(Address $address)
@@ -39,5 +43,11 @@ abstract class LX
     public function collectGarbage($item_limit = null)
     {
         return 0;
+    }
+
+    public function setCreatedTime(int $timestamp): LX
+    {
+        $this->created_time = $timestamp;
+        return $this;
     }
 }

--- a/src/l1/APCu.php
+++ b/src/l1/APCu.php
@@ -1,10 +1,16 @@
 <?php
 
-namespace LCache;
+namespace LCache\l1;
 
-class APCuL1 extends L1
+use LCache\Address;
+use LCache\Entry;
+use LCache\state\StateL1Interface;
+
+class APCu extends L1
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     private $localKeyPrefix;
 
     public function __construct($pool, StateL1Interface $state)

--- a/src/l1/L1.php
+++ b/src/l1/L1.php
@@ -1,18 +1,24 @@
 <?php
 
-namespace LCache;
+namespace LCache\l1;
+
+use LCache\Address;
+use LCache\LX;
+use LCache\state\StateL1Interface;
 
 abstract class L1 extends LX
 {
     protected $pool;
 
-    /** @var StateL1Interface */
+    /**
+     * @var StateL1Interface
+     */
     protected $state;
 
     /**
      * Constructor for all the L1 implementations.
      *
-     * @param string $pool
+     * @param string                   $pool
      *   Pool ID to group the cache data in.
      * @param \LCache\StateL1Interface $state
      *   State manager class. Used to collect hit/miss statistics as well as
@@ -41,7 +47,7 @@ abstract class L1 extends LX
 
     public function set($event_id, Address $address, $value = null, $expiration = null)
     {
-        return $this->setWithExpiration($event_id, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);
+        return $this->setWithExpiration($event_id, $address, $value, $this->created_time, $expiration);
     }
 
     abstract public function isNegativeCache(Address $address);

--- a/src/l1/NullL1.php
+++ b/src/l1/NullL1.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace LCache;
+namespace LCache\l1;
+
+use LCache\Address;
 
 class NullL1 extends StaticL1
 {

--- a/src/l1/SQLite.php
+++ b/src/l1/SQLite.php
@@ -1,10 +1,15 @@
 <?php
 
-namespace LCache;
+namespace LCache\l1;
 
-class SQLiteL1 extends L1
+use LCache\Address;
+use LCache\state\StateL1Interface;
+
+class SQLite extends L1
 {
-    /** @var \PDO */
+    /**
+     * @var \PDO
+     */
     private $dbh;
 
     protected static function tableExists(\PDO $dbh, $table_name)
@@ -64,10 +69,10 @@ class SQLiteL1 extends L1
     protected function pruneExpiredEntries()
     {
         $sth = $this->dbh->prepare('DELETE FROM entries WHERE expiration < :now');
-        $sth->bindValue(':now', $_SERVER['REQUEST_TIME'], \PDO::PARAM_INT);
+        $sth->bindValue(':now', $this->created_time, \PDO::PARAM_INT);
         try {
             $sth->execute();
-        // @codeCoverageIgnoreStart
+            // @codeCoverageIgnoreStart
         } catch (\PDOException $e) {
             $text = 'LCache SQLiteL1: Pruning Failed: ' . $e->getMessage();
             trigger_error($text, E_USER_WARNING);
@@ -146,7 +151,7 @@ class SQLiteL1 extends L1
     {
         $sth = $this->dbh->prepare('SELECT COUNT(*) AS existing FROM entries WHERE "address" = :address AND ("expiration" >= :now OR "expiration" IS NULL) AND "value" IS NOT NULL');
         $sth->bindValue(':address', $address->serialize(), \PDO::PARAM_STR);
-        $sth->bindValue(':now', $_SERVER['REQUEST_TIME'], \PDO::PARAM_INT);
+        $sth->bindValue(':now', $this->created_time, \PDO::PARAM_INT);
         $sth->execute();
         $result = $sth->fetchObject();
         return $result->existing > 0;
@@ -156,7 +161,7 @@ class SQLiteL1 extends L1
     {
         $sth = $this->dbh->prepare('SELECT COUNT(*) AS entry_count FROM entries WHERE "address" = :address AND ("expiration" >= :now OR "expiration" IS NULL) AND "value" IS NULL');
         $sth->bindValue(':address', $address->serialize(), \PDO::PARAM_STR);
-        $sth->bindValue(':now', $_SERVER['REQUEST_TIME'], \PDO::PARAM_INT);
+        $sth->bindValue(':now', $this->created_time, \PDO::PARAM_INT);
         $sth->execute();
         $result = $sth->fetchObject();
         return ($result->entry_count > 0);
@@ -180,7 +185,7 @@ class SQLiteL1 extends L1
     {
         $sth = $this->dbh->prepare('SELECT "value", "expiration", "reads", "writes", "created" FROM entries WHERE "address" = :address AND ("expiration" >= :now OR "expiration" IS NULL)');
         $sth->bindValue(':address', $address->serialize(), \PDO::PARAM_STR);
-        $sth->bindValue(':now', $_SERVER['REQUEST_TIME'], \PDO::PARAM_INT);
+        $sth->bindValue(':now', $this->created_time, \PDO::PARAM_INT);
         $sth->execute();
         $entry = $sth->fetchObject();
 

--- a/src/l1/StaticL1.php
+++ b/src/l1/StaticL1.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace LCache;
+namespace LCache\l1;
+
+use LCache\Address;
+use LCache\Entry;
+use LCache\state\StateL1Interface;
 
 class StaticL1 extends L1
 {
@@ -8,7 +12,9 @@ class StaticL1 extends L1
 
     protected $key_overhead;
 
-    /** @var array Reference to the data array for the instance data pool. */
+    /**
+     * @var array Reference to the data array for the instance data pool.
+     */
     protected $storage;
 
     public function __construct($pool, StateL1Interface $state)
@@ -76,7 +82,7 @@ class StaticL1 extends L1
             return null;
         }
         $entry = $this->storage[$local_key];
-        if (!is_null($entry->expiration) && $entry->expiration < $_SERVER['REQUEST_TIME']) {
+        if (!is_null($entry->expiration) && $entry->expiration < $this->created_time) {
             unset($this->storage[$local_key]);
             $this->recordMiss();
             return null;

--- a/src/l2/L2.php
+++ b/src/l2/L2.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace LCache;
+namespace LCache\l2;
+
+use LCache\Address;
+use LCache\LX;
+use LCache\l1\L1;
 
 abstract class L2 extends LX
 {

--- a/src/l2/StaticL2.php
+++ b/src/l2/StaticL2.php
@@ -1,6 +1,11 @@
 <?php
 
-namespace LCache;
+namespace LCache\l2;
+
+use LCache\Address;
+use LCache\Entry;
+use LCache\UnserializationException;
+use LCache\l1\L1;
 
 class StaticL2 extends L2
 {
@@ -23,7 +28,7 @@ class StaticL2 extends L2
     {
         $garbage = 0;
         foreach ($this->events as $event_id => $entry) {
-            if ($entry->expiration < $_SERVER['REQUEST_TIME']) {
+            if ($entry->expiration < $this->created_time) {
                 $garbage++;
             }
         }
@@ -34,7 +39,7 @@ class StaticL2 extends L2
     {
         $deleted = 0;
         foreach ($this->events as $event_id => $entry) {
-            if ($entry->expiration < $_SERVER['REQUEST_TIME']) {
+            if ($entry->expiration < $this->created_time) {
                 unset($this->events[$event_id]);
                 $deleted++;
             }
@@ -47,14 +52,17 @@ class StaticL2 extends L2
     // Returns an LCache\Entry
     public function getEntry(Address $address)
     {
-        $events = array_filter($this->events, function (Entry $entry) use ($address) {
-            return $entry->getAddress()->isMatch($address);
-        });
+        $events = array_filter(
+            $this->events,
+            function (Entry $entry) use ($address) {
+                return $entry->getAddress()->isMatch($address);
+            }
+        );
         $last_matching_entry = null;
         foreach ($events as $entry) {
             if ($entry->getAddress()->isEntireCache() || $entry->getAddress()->isEntireBin()) {
                 $last_matching_entry = null;
-            } elseif (!is_null($entry->expiration) && $entry->expiration < $_SERVER['REQUEST_TIME']) {
+            } elseif (!is_null($entry->expiration) && $entry->expiration < $this->created_time) {
                 $last_matching_entry = null;
             } else {
                 $last_matching_entry = clone $entry;
@@ -88,7 +96,7 @@ class StaticL2 extends L2
         if (!$value_is_serialized) {
             $value = serialize($value);
         }
-        $this->events[$this->current_event_id] = new Entry($this->current_event_id, $pool, $address, $value, $_SERVER['REQUEST_TIME'], $expiration);
+        $this->events[$this->current_event_id] = new Entry($this->current_event_id, $pool, $address, $value, $this->created_time, $expiration);
 
         // Clear existing tags linked to the item. This is much more
         // efficient with database-style indexes.

--- a/src/state/StateL1APCu.php
+++ b/src/state/StateL1APCu.php
@@ -5,7 +5,7 @@
  * L1 state manager implementation.
  */
 
-namespace LCache;
+namespace LCache\state;
 
 /**
  * L1 statistics manager storing in APCu.
@@ -14,16 +14,24 @@ namespace LCache;
  */
 class StateL1APCu implements StateL1Interface
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     private $pool;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $statusKeyHits;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $statusKeyMisses;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     private $statusKeyLastAppliedEventId;
 
     /**

--- a/src/state/StateL1Interface.php
+++ b/src/state/StateL1Interface.php
@@ -5,7 +5,7 @@
  * L1 state manager interface.
  */
 
-namespace LCache;
+namespace LCache\state;
 
 /**
  * Interface for the state manager drivers used in L1 driver implementations.

--- a/src/state/StateL1Static.php
+++ b/src/state/StateL1Static.php
@@ -5,7 +5,7 @@
  * In-memory implementation of statistics storage for L1 drivers.
  */
 
-namespace LCache;
+namespace LCache\state;
 
 /**
  * Description of StateL1Static
@@ -14,13 +14,19 @@ namespace LCache;
  */
 class StateL1Static implements StateL1Interface
 {
-    /** @var int Container variable for the cache-hit count. */
+    /**
+     * @var int Container variable for the cache-hit count.
+     */
     protected $hits;
 
-    /** @var int Container variable for the cache-miss count. */
+    /**
+     * @var int Container variable for the cache-miss count.
+     */
     protected $misses;
 
-    /** @var int Container variable for the last applied event id value. */
+    /**
+     * @var int Container variable for the last applied event id value.
+     */
     protected $last_applied_event_id;
 
     /**

--- a/tests/DatabaseSchema.php
+++ b/tests/DatabaseSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LCache;
+
+use PDO;
+
+class DatabaseSchema
+{
+
+    public static function create(PDO $dbh, string $prefix = '')
+    {
+        $dbh->exec('PRAGMA foreign_keys = ON');
+
+        $dbh->exec('CREATE TABLE ' . $prefix . 'lcache_events("event_id" INTEGER PRIMARY KEY AUTOINCREMENT, "pool" TEXT NOT NULL, "address" TEXT, "value" BLOB, "expiration" INTEGER, "created" INTEGER NOT NULL)');
+        $dbh->exec('CREATE INDEX ' . $prefix . 'latest_entry ON ' . $prefix . 'lcache_events ("address", "event_id")');
+
+        // @TODO: Set a proper primary key and foreign key relationship.
+        $dbh->exec('CREATE TABLE ' . $prefix . 'lcache_tags("tag" TEXT, "event_id" INTEGER, PRIMARY KEY ("tag", "event_id"), FOREIGN KEY("event_id") REFERENCES ' . $prefix . 'lcache_events("event_id") ON DELETE CASCADE)');
+        $dbh->exec('CREATE INDEX ' . $prefix . 'rewritten_entry ON ' . $prefix . 'lcache_tags ("event_id")');
+    }
+}

--- a/tests/EntryTest.php
+++ b/tests/EntryTest.php
@@ -12,12 +12,13 @@ class EntryTest extends \PHPUnit_Framework_TestCase
 
     public function testEntryTTL()
     {
+        $created_time = time();
         $myaddr = new Address('mybin', 'mykey');
-        $entry = new Entry(0, 'mypool', $myaddr, 'value', $_SERVER['REQUEST_TIME'], $_SERVER['REQUEST_TIME'] + 1);
+        $entry = new Entry(0, 'mypool', $myaddr, 'value', $created_time, $created_time + 1);
         $this->assertEquals(1, $entry->getTTL());
 
         // TTL should be zero for already-expired items.
-        $old_entry = new Entry(0, 'mypool', $myaddr, 'value', $_SERVER['REQUEST_TIME'], $_SERVER['REQUEST_TIME'] - 1);
+        $old_entry = new Entry(0, 'mypool', $myaddr, 'value', $created_time, $created_time - 1);
         $this->assertEquals(0, $old_entry->getTTL());
     }
 }

--- a/tests/L1/APCuTest.php
+++ b/tests/L1/APCuTest.php
@@ -5,14 +5,14 @@
  * Test file for the APCu L1 driver in LCache library.
  */
 
-namespace LCache\L1;
+namespace LCache\l1;
 
 /**
  * APCuTest concrete implementation.
  *
  * @author ndobromirov
  */
-class APCuTest extends \LCache\L1CacheTest
+class APCuTest extends L1CacheTest
 {
 
     protected function setUp()

--- a/tests/L1/NullTest.php
+++ b/tests/L1/NullTest.php
@@ -6,7 +6,7 @@
  * and open the template in the editor.
  */
 
-namespace LCache\L1;
+namespace LCache\l1;
 
 use LCache\Address;
 
@@ -15,7 +15,7 @@ use LCache\Address;
  *
  * @author ndobromirov
  */
-class NullTest extends \LCache\L1CacheTest
+class NullTest extends L1CacheTest
 {
 
     protected function driverName()

--- a/tests/L1/SQLiteTest.php
+++ b/tests/L1/SQLiteTest.php
@@ -5,14 +5,14 @@
  * Test file for the SQLite L1 driver in LCache library.
  */
 
-namespace LCache\L1;
+namespace LCache\l1;
 
 /**
  * SQLiteTest concrete implementation.
  *
  * @author ndobromirov
  */
-class SQLiteTest extends \LCache\L1CacheTest
+class SQLiteTest extends L1CacheTest
 {
     /**
      * {@inheritDoc}

--- a/tests/L1/StaticTest.php
+++ b/tests/L1/StaticTest.php
@@ -5,14 +5,14 @@
  * Test file for the Static L1 driver in LCache library.
  */
 
-namespace LCache\L1;
+namespace LCache\l1;
 
 /**
  * StaticTest concrete implementation.
  *
  * @author ndobromirov
  */
-class StaticTest extends \LCache\L1CacheTest
+class StaticTest extends L1CacheTest
 {
     /**
      * {@inheritDoc}

--- a/tests/l2/DatabaseTest.php
+++ b/tests/l2/DatabaseTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace LCache\l2;
+
+use LCache\Address;
+use LCache\DatabaseSchema;
+use PDO;
+use PHPUnit_Extensions_Database_DataSet_DefaultDataSet;
+use PHPUnit_Extensions_Database_TestCase;
+
+class DatabaseTest extends PHPUnit_Extensions_Database_TestCase
+{
+    protected $dbh = null;
+
+    public function testDatabaseBatchDeletion()
+    {
+        DatabaseSchema::create($this->dbh);
+        $l2 = (new Database($this->dbh))->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+
+        $mybin = new Address('mybin', null);
+        $l2->delete('mypool', $mybin);
+
+        $this->assertNull($l2->get($myaddr));
+    }
+
+    public function testDatabaseCleanupAfterWrite()
+    {
+        DatabaseSchema::create($this->dbh);
+        $myaddr = new Address('mybin', 'mykey');
+
+        // Write to the key with the first client.
+        $l2_client_a = (new Database($this->dbh))->setCreatedTime(time());
+        $event_id_a = $l2_client_a->set('mypool', $myaddr, 'myvalue');
+
+        // Verify that the first event exists and has the right value.
+        $event = $l2_client_a->getEvent($event_id_a);
+        $this->assertEquals('myvalue', $event->value);
+
+        // Use a second client. This gives us a fresh event_id_low_water,
+        // just like a new PHP request.
+        $l2_client_b = (new Database($this->dbh))->setCreatedTime(time());
+
+        // Write to the same key with the second client.
+        $event_id_b = $l2_client_b->set('mypool', $myaddr, 'myvalue2');
+
+        // Verify that the second event exists and has the right value.
+        $event = $l2_client_b->getEvent($event_id_b);
+        $this->assertEquals('myvalue2', $event->value);
+
+        // Call the same method as on destruction. This second client should
+        // now prune any writes to the key from earlier requests.
+        $l2_client_b->pruneReplacedEvents();
+
+        // Verify that the first event no longer exists.
+        $event = $l2_client_b->getEvent($event_id_a);
+        $this->assertNull($event);
+    }
+
+    public function testExistsDatabase()
+    {
+        DatabaseSchema::create($this->dbh);
+        $l2 = (new Database($this->dbh))->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+        $this->assertTrue($l2->exists($myaddr));
+        $l2->delete('mypool', $myaddr);
+        $this->assertFalse($l2->exists($myaddr));
+    }
+
+    public function testEmptyCleanUpDatabase()
+    {
+        DatabaseSchema::create($this->dbh);
+        $l2 = (new Database($this->dbh))->setCreatedTime(time());
+    }
+
+    public function testDatabasePrefix()
+    {
+        DatabaseSchema::create($this->dbh, 'myprefix_');
+        $l2 = (new Database($this->dbh, 'myprefix_'))->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue', null, ['mytag']);
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+    }
+
+    /**
+     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+     */
+    protected function getConnection()
+    {
+        $this->dbh = new PDO('sqlite::memory:');
+        $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        return $this->createDefaultDBConnection($this->dbh, ':memory:');
+    }
+
+    /**
+    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+    */
+    protected function getDataSet()
+    {
+        return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
+}

--- a/tests/l2/L2CacheTest.php
+++ b/tests/l2/L2CacheTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LCache\l2;
+
+use LCache\Address;
+use LCache\DatabaseSchema;
+use PDO;
+use PHPUnit_Extensions_Database_DataSet_DefaultDataSet;
+use PHPUnit_Extensions_Database_TestCase;
+
+class L2CacheTest extends PHPUnit_Extensions_Database_TestCase
+{
+    protected $dbh = null;
+
+    public function testDatabasePrefix()
+    {
+        DatabaseSchema::create($this->dbh, 'myprefix_');
+        $l2 = (new Database($this->dbh, 'myprefix_'))->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue', null, ['mytag']);
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+    }
+
+    /**
+     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+     */
+    protected function getConnection()
+    {
+        $this->dbh = new PDO('sqlite::memory:');
+        $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        return $this->createDefaultDBConnection($this->dbh, ':memory:');
+    }
+
+    /**
+    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+    */
+    protected function getDataSet()
+    {
+        return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
+}

--- a/tests/l2/StaticL2Test.php
+++ b/tests/l2/StaticL2Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace LCache\l2;
+
+use LCache\Address;
+use PHPUnit_Framework_TestCase;
+
+class StaticL2Test extends PHPUnit_Framework_TestCase
+{
+    public function testStaticL2Expiration()
+    {
+        $l2 = (new StaticL2())->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue', -1);
+        $this->assertNull($l2->get($myaddr));
+    }
+
+    public function testStaticL2Reread()
+    {
+        $l2 = new StaticL2();
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+        $this->assertEquals('myvalue', $l2->get($myaddr));
+    }
+
+    public function testClearStaticL2()
+    {
+        $l2 = (new StaticL2())->setCreatedTime(time());
+        $myaddr = new Address('mybin', 'mykey');
+        $l2->set('mypool', $myaddr, 'myvalue');
+        $l2->delete('mypool', new Address());
+        $this->assertNull($l2->get($myaddr));
+    }
+}


### PR DESCRIPTION
### Overview
This pull request:

- [x] Remove php global variables
- [x] Split namespaces
- [x] Refactor tests

### Summary
Separated l1 and l2 into their own namespaces, refactored tests to match. Removed PHP global variables.

### Description
